### PR TITLE
fixes for compilation issue in JMSMessageListenerUtils

### DIFF
--- a/utils/src/main/java/org/wso2/ei/module/jms/Constants.java
+++ b/utils/src/main/java/org/wso2/ei/module/jms/Constants.java
@@ -34,6 +34,7 @@ import static org.ballerinalang.jvm.util.BLangConstants.VERSION_SEPARATOR;
  */
 public class Constants {
 
+    static final String ORG = "org";
     static final String PACKAGE_NAME = "wso2/jms";
     public static final String VERSION = "0.6.0";
 

--- a/utils/src/main/java/org/wso2/ei/module/jms/JmsMessageListenerUtils.java
+++ b/utils/src/main/java/org/wso2/ei/module/jms/JmsMessageListenerUtils.java
@@ -22,6 +22,7 @@ package org.wso2.ei.module.jms;
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.BallerinaValues;
 import org.ballerinalang.jvm.types.AttachedFunction;
+import org.ballerinalang.jvm.types.BPackage;
 import org.ballerinalang.jvm.values.HandleValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 
@@ -92,8 +93,8 @@ public class JmsMessageListenerUtils {
                 messageObjectName = Constants.MESSAGE_BAL_OBJECT_NAME;
                 specificFunctionName = Constants.SERVICE_RESOURCE_ON_OTHER_MESSAGE;
             }
-
-            ObjectValue param = BallerinaValues.createObjectValue(Constants.PACKAGE_NAME, messageObjectName,
+            BPackage packageId = new BPackage(Constants.ORG, Constants.PACKAGE_NAME, Constants.VERSION);
+            ObjectValue param = BallerinaValues.createObjectValue(packageId, messageObjectName,
                                                                   new HandleValue(message));
             Object[] params = {param, true};
 


### PR DESCRIPTION
## Purpose
> Tried to build the utils package against ballerina alpha3, encountered an issue in below.
**Compilation failure
[ERROR] /Users/hasunie/RD/MC/test/jms/module-jms/utils/src/main/java/org/wso2/ei/module/jms/JmsMessageListenerUtils.java:[97,86] incompatible types: java.lang.String cannot be converted to org.ballerinalang.jvm.types.BPackage**
This PR will fix the compilation issue.

