### PR TITLE
Upgrade the JMS Module version for Ballerina 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ The following sections provide details on how to use the JMS connector.
 
 ## Compatibility
 
-|                             |           Version           |
-|:---------------------------:|:---------------------------:|
-| Ballerina Language          |            1.0.1            |
+|  Ballerina Language Version |       JMS Module Version       |
+|:---------------------------:|:------------------------------:|
+|         1.0.x               |             0.6.x              |
+|         1.1.x               |             0.7.x              |
 
 ## Samples
 

--- a/compiler-plugin/pom.xml
+++ b/compiler-plugin/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.wso2.ei.b7a</groupId>
         <artifactId>module-jms</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jms-compiler-plugin</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.0</version>
     <packaging>jar</packaging>
     <name>JMS Compiler Plugin</name>
 

--- a/compiler-plugin/src/main/java/org/wso2/ei/b7a/jms/ServiceCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/org/wso2/ei/b7a/jms/ServiceCompilerPlugin.java
@@ -51,7 +51,7 @@ import static org.ballerinalang.jvm.util.BLangConstants.VERSION_SEPARATOR;
 public class ServiceCompilerPlugin extends AbstractCompilerPlugin {
 
     private static final String PACKAGE_NAME = "wso2/jms";
-    private static final String VERSION = "0.6.3";
+    private static final String VERSION = "0.7.0";
 
     private static final String PACKAGE_NAME_WITH_VERSION = PACKAGE_NAME + VERSION_SEPARATOR + VERSION;
     private static final String MESSAGE_NAME = "Message";

--- a/jms/Ballerina.lock
+++ b/jms/Ballerina.lock
@@ -1,9 +1,9 @@
 org_name = "wso2"
-version = "0.6.3"
+version = "0.7.0"
 lockfile_version = "1.0.0"
 ballerina_version = "1.1.0"
 
-[[imports."wso2/jms:0.6.3"]]
+[[imports."wso2/jms:0.7.0"]]
 org_name = "ballerinax"
 name = "java"
 version = "0.0.0"

--- a/jms/Ballerina.toml
+++ b/jms/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name= "wso2"
-version= "0.6.3"
+version= "0.7.0"
 license= ["Apache-2.0"]
 authors = ["WSO2"]
 keywords = ["jms"]
@@ -13,9 +13,9 @@ target = "java8"
 
   [[platform.libraries]]
   module = "jms"
-  path = "../utils/target/jms-utils-0.6.3.jar"
+  path = "../utils/target/jms-utils-0.7.0.jar"
   artifactId = "jms-utils"
-  version = "0.6.3"
+  version = "0.7.0"
   groupId = "org.wso2.ei"
 
   [[platform.libraries]]

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.wso2.ei.b7a</groupId>
         <artifactId>module-jms</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>b7a-jms-connector</artifactId>
     <packaging>pom</packaging>
-    <version>0.6.3</version>
+    <version>0.7.0</version>
     <name>Ballerina JMS Connector</name>
 
     <build>

--- a/jms/src/jms/Module.md
+++ b/jms/src/jms/Module.md
@@ -23,9 +23,10 @@ Currently, the following JMS API Classes are supported through this module.
  
 ## Compatibility
  
- |                             |           Version           |
- |:---------------------------:|:---------------------------:|
- | Ballerina Language          |            1.0.1            |
+|  Ballerina Language Version |       JMS Module Version       |
+|:---------------------------:|:------------------------------:|
+|         1.0.x               |             0.6.x              |
+|         1.1.x               |             0.7.x              |
 
 ## Samples
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.ei.b7a</groupId>
     <artifactId>module-jms</artifactId>
     <packaging>pom</packaging>
-    <version>0.6.3</version>
+    <version>0.7.0</version>
     <name>Ballerina JMS Module</name>
 
     <modules>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,11 +24,11 @@
     <parent>
         <artifactId>module-jms</artifactId>
         <groupId>org.wso2.ei.b7a</groupId>
-        <version>0.6.3</version>
+        <version>0.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>0.6.3</version>
+    <version>0.7.0</version>
     <artifactId>jms-utils</artifactId>
     <packaging>jar</packaging>
     <name>JMS Utils</name>

--- a/utils/src/main/java/org/wso2/ei/b7a/jms/Constants.java
+++ b/utils/src/main/java/org/wso2/ei/b7a/jms/Constants.java
@@ -35,7 +35,7 @@ public class Constants {
 
     static final String ORG = "wso2";
     static final String PACKAGE_NAME = "jms";
-    public static final String VERSION = "0.6.3";
+    public static final String VERSION = "0.7.0";
 
     public static final String PACKAGE_NAME_WITH_VERSION = PACKAGE_NAME + VERSION_SEPARATOR + VERSION;
 


### PR DESCRIPTION
## Purpose
> Upgrade the JMS Module version to 0.7.0 to be in line with the Ballerina version 1.1.0.
