### PR TITLE
Add metrics observability to Ballerina JMS Connector

### DIFF
--- a/jms/src/jms/Observability/JMSMetricsUtils.bal
+++ b/jms/src/jms/Observability/JMSMetricsUtils.bal
@@ -28,20 +28,20 @@ function registerAndIncrementCounter(observe:Counter counter) {
     counter.increment();
 }
 
-# Register and increment guage
+# Register and increment gauge
 #
-# + guage - guage to be registered and incremented
-function registerAndIncrementGuage(observe:Gauge guage) {
-    error? result = guage.register();
+# + gauge - gauge to be registered and incremented
+function registerAndIncrementGauge(observe:Gauge gauge) {
+    error? result = gauge.register();
     if (result is error) {
-        log:printError("Error in registering guage : " + guage.name, result);
+        log:printError("Error in registering gauge : " + gauge.name, result);
     }
-    guage.increment();
+    gauge.increment();
 }
 
-# Decrement guage
+# Decrement gauge
 #
-# + guage - guage to be decremented
-function decrementGuage(observe:Gauge guage) {
-    guage.decrement();
+# + gauge - gauge to be decremented
+function decrementGauge(observe:Gauge gauge) {
+    gauge.decrement();
 }

--- a/jms/src/jms/Observability/JMSMetricsUtils.bal
+++ b/jms/src/jms/Observability/JMSMetricsUtils.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/observe;
+import ballerina/log;
+
+# Register and increment counter
+#
+# + counter - counter to be registered and incremented
+function registerAndIncrementCounter(observe:Counter counter) {
+    error? result = counter.register();
+    if (result is error) {
+        log:printError("Error in registering counter : " + counter.name, err = result);
+    }
+    counter.increment();
+}
+
+# Register and increment guage
+#
+# + guage - guage to be registered and incremented
+function registerAndIncrementGuage(observe:Gauge guage) {
+    error? result = guage.register();
+    if (result is error) {
+        log:printError("Error in registering guage : " + guage.name, err = result);
+    }
+    guage.increment();
+}
+
+# Decrement guage
+#
+# + guage - guage to be decremented
+function decrementGuage(observe:Gauge guage) {
+    guage.decrement();
+}

--- a/jms/src/jms/Observability/JMSMetricsUtils.bal
+++ b/jms/src/jms/Observability/JMSMetricsUtils.bal
@@ -23,7 +23,7 @@ import ballerina/log;
 function registerAndIncrementCounter(observe:Counter counter) {
     error? result = counter.register();
     if (result is error) {
-        log:printError("Error in registering counter : " + counter.name, err = result);
+        log:printError("Error in registering counter : " + counter.name, result);
     }
     counter.increment();
 }
@@ -34,7 +34,7 @@ function registerAndIncrementCounter(observe:Counter counter) {
 function registerAndIncrementGuage(observe:Gauge guage) {
     error? result = guage.register();
     if (result is error) {
-        log:printError("Error in registering guage : " + guage.name, err = result);
+        log:printError("Error in registering guage : " + guage.name, result);
     }
     guage.increment();
 }

--- a/jms/src/jms/Observability/JMSObservabilityConstants.bal
+++ b/jms/src/jms/Observability/JMSObservabilityConstants.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const TOTAL_JMS_CONNECTIONS = "JMS_Connection_total";
+const TOTAL_JMS_MESSAGES_RECEIVED = "JMS_Consumer_Messages_Received_total";
+const TOTAL_JMS_MESSAGES_SENT = "JMS_Producer_Messages_Sent_total";
+const TOTAL_JMS_SESSIONS = "JMS_Session_total";
+const TOTAL_JMS_UNSUBSCRIBES = "JMS_Unsubscribe_total";
+const TOTAL_JMS_TEMPORARY_QUEUES = "JMS_TemporaryQueue_total";
+const TOTAL_JMS_TEMPORARY_TOPICS = "JMS_TemporaryTopic_total";
+const TOTAL_JMS_QUEUES = "JMS_Queue_total";
+const TOTAL_JMS_TOPICS = "JMS_Topic_total";
+const TOTAL_JMS_MESSAGES_CREATED = "JMS_Messages_Created_total";
+const TOTAL_JMS_TEXT_MESSAGES_WITH_TEXT_CREATED = "JMS_Text_Messages_With_Text_Created_total";
+const TOTAL_JMS_TEXT_MESSAGES_CREATED = "JMS_Text_Messages_Created_total";
+const TOTAL_JMS_MAP_MESSAGES_CREATED = "JMS_Map_Messages_Created_total";
+const TOTAL_JMS_STREAM_MESSAGES_CREATED = "JMS_Stream_Messages_Created_total";
+const TOTAL_JMS_BYTE_MESSAGES_CREATED = "JMS_Byte_Messages_Created_total";
+const TOTAL_JMS_PRODUCERS = "JMS_Producer_total";
+const TOTAL_JMS_CONSUMERS = "JMS_Consumer_total";
+const TOTAL_JMS_DURABLE_SUBSCRIBERS = "JMS_DurableSubscriber_total";
+const TOTAL_JMS_SHARED_CONSUMERS = "JMS_SharedConsumer_total";
+const TOTAL_JMS_SHARED_DURABLE_CONSUMERS = "JMS_SharedDurableConsumer_total";
+
+const ACTIVE_JMS_CONSUMERS = "JMS_Consumer_active";
+const ACTIVE_JMS_TEMPORARY_QUEUES = "JMS_TemporaryQueue_active";
+const ACTIVE_JMS_TEMPORARY_TOPICS = "JMS_TemporaryTopic_active";

--- a/jms/src/jms/connection.bal
+++ b/jms/src/jms/connection.bal
@@ -16,6 +16,7 @@
 
 import ballerinax/java;
 import ballerina/log;
+import ballerina/observe;
 
 # Represents JMS Connection
 #
@@ -42,6 +43,7 @@ public type Connection client object {
         handle|error value = createJmsConnection(icf, providerUrl, factoryName, self.config.properties);
         if (value is handle) {
             self.jmsConnection = value;
+            registerAndIncrementCounter(new observe:Counter(TOTAL_JMS_CONNECTIONS));
             log:printDebug("Successfully connected to broker.");
             return;
         } else {

--- a/jms/src/jms/message_consumer.bal
+++ b/jms/src/jms/message_consumer.bal
@@ -19,7 +19,7 @@ import ballerinax/java;
 import ballerina/'lang\.object as lang;
 import ballerina/observe;
 
-observe:Gauge consumerGuage = new(ACTIVE_JMS_CONSUMERS);
+observe:Gauge consumerGauge = new(ACTIVE_JMS_CONSUMERS);
 
 public type MessageConsumer client object {
 
@@ -28,7 +28,7 @@ public type MessageConsumer client object {
 
     function __init(handle jmsMessageConsumer) {
         self.jmsConsumer = jmsMessageConsumer;
-        registerAndIncrementGuage(consumerGuage);
+        registerAndIncrementGauge(consumerGauge);
     }
 
     # Binds the queue receiver endpoint to a service.
@@ -67,7 +67,7 @@ public type MessageConsumer client object {
     }
 
     private function closeConsumer() returns error? {
-        decrementGuage(consumerGuage);
+        decrementGauge(consumerGauge);
         return self->close();
     }
 

--- a/jms/src/jms/message_consumer.bal
+++ b/jms/src/jms/message_consumer.bal
@@ -17,6 +17,9 @@
 import ballerina/log;
 import ballerinax/java;
 import ballerina/'lang\.object as lang;
+import ballerina/observe;
+
+observe:Gauge consumerGuage = new(ACTIVE_JMS_CONSUMERS);
 
 public type MessageConsumer client object {
 
@@ -25,6 +28,7 @@ public type MessageConsumer client object {
 
     function __init(handle jmsMessageConsumer) {
         self.jmsConsumer = jmsMessageConsumer;
+        registerAndIncrementGuage(consumerGuage);
     }
 
     # Binds the queue receiver endpoint to a service.
@@ -63,11 +67,13 @@ public type MessageConsumer client object {
     }
 
     private function closeConsumer() returns error? {
+        decrementGuage(consumerGuage);
         return self->close();
     }
 
     public remote function receive(int timeoutMillis = 0) returns Message|()|error {
         var response = receiveJmsMessage(self.jmsConsumer, timeoutMillis);
+        registerAndIncrementCounter(new observe:Counter(TOTAL_JMS_MESSAGES_RECEIVED));
         if (response is handle) {
             if (java:isNull(response)) {
                 return ();

--- a/jms/src/jms/message_producer.bal
+++ b/jms/src/jms/message_producer.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerinax/java;
+import ballerina/observe;
 
 # JMS Message Producer client object to send messages to both queues and topics.
 #
@@ -34,6 +35,7 @@ public type MessageProducer client object {
     # + message - Message to be sent to the JMS provider
     # + return - Error if unable to send the message to the queue
     public remote function send(Message message) returns error? {
+        registerAndIncrementCounter(new observe:Counter(TOTAL_JMS_MESSAGES_SENT));
         return send(self.jmsProducer, message.getJmsMessage());
     }
 

--- a/jms/src/jms/temporary_queue.bal
+++ b/jms/src/jms/temporary_queue.bal
@@ -17,7 +17,7 @@
 import ballerinax/java;
 import ballerina/observe;
 
-observe:Gauge temporaryQueueGuage = new(ACTIVE_JMS_TEMPORARY_QUEUES);
+observe:Gauge temporaryQueueGauge = new(ACTIVE_JMS_TEMPORARY_QUEUES);
 
 # Represent the JMS temporary queue
 public type TemporaryQueue object {
@@ -29,7 +29,7 @@ public type TemporaryQueue object {
     #
     # + handle - The java reference to the jms text message.
     function __init(handle temporaryQueue) {
-        registerAndIncrementGuage(temporaryQueueGuage);
+        registerAndIncrementGauge(temporaryQueueGauge);
         self.jmsDestination = temporaryQueue;
     }
 
@@ -56,7 +56,7 @@ public type TemporaryQueue object {
     #
     # + return - Returns an error if it fails.
     public function delete() returns error? {
-        decrementGuage(temporaryQueueGuage);
+        decrementGauge(temporaryQueueGauge);
         return deleteTemporaryQueue(self.jmsDestination);
     }
 

--- a/jms/src/jms/temporary_queue.bal
+++ b/jms/src/jms/temporary_queue.bal
@@ -15,6 +15,9 @@
 // under the License.
 
 import ballerinax/java;
+import ballerina/observe;
+
+observe:Gauge temporaryQueueGuage = new(ACTIVE_JMS_TEMPORARY_QUEUES);
 
 # Represent the JMS temporary queue
 public type TemporaryQueue object {
@@ -26,6 +29,7 @@ public type TemporaryQueue object {
     #
     # + handle - The java reference to the jms text message.
     function __init(handle temporaryQueue) {
+        registerAndIncrementGuage(temporaryQueueGuage);
         self.jmsDestination = temporaryQueue;
     }
 
@@ -52,6 +56,7 @@ public type TemporaryQueue object {
     #
     # + return - Returns an error if it fails.
     public function delete() returns error? {
+        decrementGuage(temporaryQueueGuage);
         return deleteTemporaryQueue(self.jmsDestination);
     }
 

--- a/jms/src/jms/temporary_topic.bal
+++ b/jms/src/jms/temporary_topic.bal
@@ -17,7 +17,7 @@
 import ballerinax/java;
 import ballerina/observe;
 
-observe:Gauge temporaryTopicGuage = new(ACTIVE_JMS_TEMPORARY_TOPICS);
+observe:Gauge temporaryTopicGauge = new(ACTIVE_JMS_TEMPORARY_TOPICS);
 
 # Represent the JMS temporary topic
 public type TemporaryTopic object {
@@ -29,7 +29,7 @@ public type TemporaryTopic object {
     #
     # + handle - The java reference to the jms text message.
     function __init(handle temporaryTopic) {
-        registerAndIncrementGuage(temporaryTopicGuage);
+        registerAndIncrementGauge(temporaryTopicGauge);
         self.jmsDestination = temporaryTopic;
     }
 
@@ -56,7 +56,7 @@ public type TemporaryTopic object {
     #
     # + return - Returns an error if it fails.
     public function delete() returns error? {
-        decrementGuage(temporaryTopicGuage);
+        decrementGauge(temporaryTopicGauge);
         return deleteTemporaryTopic(self.jmsDestination);
     }
 

--- a/jms/src/jms/temporary_topic.bal
+++ b/jms/src/jms/temporary_topic.bal
@@ -15,6 +15,9 @@
 // under the License.
 
 import ballerinax/java;
+import ballerina/observe;
+
+observe:Gauge temporaryTopicGuage = new(ACTIVE_JMS_TEMPORARY_TOPICS);
 
 # Represent the JMS temporary topic
 public type TemporaryTopic object {
@@ -26,6 +29,7 @@ public type TemporaryTopic object {
     #
     # + handle - The java reference to the jms text message.
     function __init(handle temporaryTopic) {
+        registerAndIncrementGuage(temporaryTopicGuage);
         self.jmsDestination = temporaryTopic;
     }
 
@@ -52,6 +56,7 @@ public type TemporaryTopic object {
     #
     # + return - Returns an error if it fails.
     public function delete() returns error? {
+        decrementGuage(temporaryTopicGuage);
         return deleteTemporaryTopic(self.jmsDestination);
     }
 


### PR DESCRIPTION
## Purpose
This PR will add metrics observability to Ballerina JMS Connector.

The following metrics will be able to capture:

- Total JMS Connections
- Total JMS Sessions
- Total JMS Producers
- Total JMS Consumers
- Total JMS Topics
- Total JMS Queues
- Total JMS Messages sent
- Total JMS Messages received
- Total JMS Temporary queues
- Total JMS Temporary topics
- Total JMS Unsubscribes
- Total JMS Durable subscribers
- Total JMS Shared consumers
- Total JMS Shared durable consumers
- Total JMS Messages created
- Total JMS Text messages created
- Total JMS Text messages with text created
- Total JMS Map messages created
- Total JMS Stream messages created
- Total JMS Byte messages created
- Active JMS Consumers
- Active JMS Temporary queues
- Active JMS Temporary topics

Resolves: https://github.com/wso2-ballerina/module-jms/issues/51