### PR TITLE
Update version from 1.2.0-SNAPSHOT to 1.2.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.2.0-SNAPSHOT
+version=1.2.1-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 checkstylePluginVersion=10.12.1


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the project version in the Gradle build configuration from `1.2.0-SNAPSHOT` to `1.2.1-SNAPSHOT`. This is a minor version increment applied to the `version` property in `gradle.properties`.

**Changes:**
- Updated `gradle.properties`: version property incremented from `1.2.0-SNAPSHOT` to `1.2.1-SNAPSHOT`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->